### PR TITLE
Added support for uploaded images

### DIFF
--- a/bbpress-display-image-exif.php
+++ b/bbpress-display-image-exif.php
@@ -4,6 +4,7 @@
  * Plugin Name: bbPress Display Image Exif
  * Plugin URI: https://github.com/BenjaminMedia/bbpress-display-image-exif
  * Description: Display exif data for the images attached in posts and comments
+ * Version: 0.1.1
  * Author:      Jonas Kjærgaard
  * Domain Path: /languages/
  * License:     GPL
@@ -22,6 +23,7 @@ spl_autoload_register(function ($className) {
         require_once(__DIR__ . DIRECTORY_SEPARATOR . Plugin::CLASS_DIR . DIRECTORY_SEPARATOR . $className . '.php');
     }
 });
+
 class Plugin
 {
     /**
@@ -83,12 +85,86 @@ class Plugin
         return $text;
     }
 
+    /**
+     * Displays the image exif data
+     */
     public function displayImageExif(){
         $post_id = get_the_ID();
 
         global $wpdb;
         $rows = $wpdb->get_results("select meta_value from wp_postmeta where meta_key='_bbp_files' and post_id=" . $post_id);
 
+        // Dose it contain a imported image
+        if ($rows !== null) {
+            $this->getImportedImageExif($rows);
+        }
+
+        $this->getImageExif($post_id);
+    }
+
+    /**
+     * Get EXIF data for a uploaded image
+     * @param $post_id
+     */
+    private function getImageExif($post_id)
+    {
+        // Set args for getting children for the post_id
+        $args = [
+            'order' => 'ASC',
+            'post_mime_type' => 'image',
+            'post_parent' => $post_id,
+            'post_status' => null,
+            'post_type' => 'attachment',
+        ];
+
+        $attachments = get_children( $args );
+
+        // Skip if empty
+        if(!$attachments)
+            return;
+
+        $output = "";
+        // Go through every attachment and echo exif data
+        foreach ($attachments as $attachment)
+        {
+            $metadata = wp_get_attachment_metadata($attachment->ID);
+
+            $output .= '
+    <div class="mdForumAttachment">
+    <div class="mdImg">
+    <a href="' . wp_get_attachment_url($attachment->ID) . '"><img src="' . wp_get_attachment_url($attachment->ID) . '" alt="" title="" width="124" height="124" /></a></div>
+    </div>';
+            $exif = '';
+
+            foreach ($metadata['image_meta'] as $key => $value) {
+                if ($key == 'aperture') {
+                    $exif .= ' | <strong>Aperture:</strong>&nbsp;f/' . $value;
+                }
+                if ($key == 'camera') {
+                    $exif .= ' | <strong>Camera:</strong>&nbsp;' . $value;
+                }
+                if ($key == 'shutter_speed') {
+                    $exif .= ' | <strong>Exposure time:</strong>&nbsp;' . self::format_exp_time($value);
+                }
+                if ($key == 'focal_length') {
+                    $exif .= ' | <strong>Focal length:</strong>&nbsp;' . $value . ' mm';
+                }
+                if ($key == 'iso') {
+                    $exif .= ' | <strong>ISO:</strong>&nbsp;' . $value;
+                }
+            }
+
+            $output .= '<span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>';
+        }
+
+        echo $output;
+    }
+
+    /**
+     * Get the data from the import of old images
+     * @param $rows
+     */
+    private function getImportedImageExif($rows) {
         $rows = $rows[0]->meta_value;
         $rows = json_decode($rows);
 
@@ -96,13 +172,13 @@ class Plugin
             $output = "";
             foreach ($rows as $row) {
                 $output .= '
-<div class="mdForumAttachment">
-<div class="mdImg">
-<a href="' . $row->path . '"><img src="' . $row->path . '?w=124&h=124&fit=crop" alt="" title="" width="124" height="124" /></a></div>
-<div class="mdTxt">
-<p>' . self::fixCharacters($row->title) . '</p>
-</div>
-</div>';
+    <div class="mdForumAttachment">
+    <div class="mdImg">
+    <a href="' . $row->path . '"><img src="' . $row->path . '?w=124&h=124&fit=crop" alt="" title="" width="124" height="124" /></a></div>
+    <div class="mdTxt">
+    <p>' . self::fixCharacters($row->title) . '</p>
+    </div>
+    </div>';
                 $exif = '';
                 if ($row->fnumber) {
                     $exif .= ' | <strong>Aperture:</strong>&nbsp;f/' . $row->fnumber;
@@ -138,6 +214,8 @@ class Plugin
      * E.g.:
      * 2 seconds => "2
      * 0.25 second => 1/4
+     * @param $time float
+     * @return string
      */
     private function format_exp_time($time){
         if($time<1){

--- a/bbpress-display-image-exif.php
+++ b/bbpress-display-image-exif.php
@@ -94,7 +94,7 @@ class Plugin
         global $wpdb;
         $rows = $wpdb->get_results("select meta_value from wp_postmeta where meta_key='_bbp_files' and post_id=" . $post_id);
 
-        // Dose it contain a imported image
+        // Does it contain an imported image
         if ($rows !== null) {
             $this->getImportedImageExif($rows);
         }
@@ -120,8 +120,9 @@ class Plugin
         $attachments = get_children( $args );
 
         // Skip if empty
-        if(!$attachments)
+        if (!$attachments) {
             return;
+        }
 
         $output = "";
         $exifIsEmpty = false;
@@ -130,11 +131,6 @@ class Plugin
         {
             $metadata = wp_get_attachment_metadata($attachment->ID);
 
-            $output .= '
-    <div class="mdForumAttachment">
-    <div class="mdImg">
-    <a href="' . wp_get_attachment_url($attachment->ID) . '"><img src="' . wp_get_attachment_url($attachment->ID) . '" alt="" title="" width="124" height="124" /></a></div>
-    </div>';
             $exif = '';
 
             foreach ($metadata['image_meta'] as $key => $value) {
@@ -154,10 +150,20 @@ class Plugin
                     $exif .= ' | <strong>ISO:</strong>&nbsp;' . $value;
                 }
             }
-            if (!$exif)
-                $exifIsEmpty = true;
 
-            $output .= (!$exifIsEmpty) ? '<span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>' : '';
+
+            var_dump($exif);
+
+            //$output .= ($exif) ? '<span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>' : '';
+
+
+            if ($exif) {
+                $output .= '
+    <div class="mdForumAttachment">
+    <div class="mdImg">
+    <a href="' . wp_get_attachment_url($attachment->ID) . '"><img src="' . wp_get_attachment_url($attachment->ID) . '" alt="" title="" width="124" height="124" /></a></div>
+    </div><span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>';
+            }
         }
 
         if(!$exifIsEmpty)

--- a/bbpress-display-image-exif.php
+++ b/bbpress-display-image-exif.php
@@ -124,6 +124,7 @@ class Plugin
             return;
 
         $output = "";
+        $exifIsEmpty = false;
         // Go through every attachment and echo exif data
         foreach ($attachments as $attachment)
         {
@@ -137,27 +138,30 @@ class Plugin
             $exif = '';
 
             foreach ($metadata['image_meta'] as $key => $value) {
-                if ($key == 'aperture') {
+                if ($key == 'aperture' && $value != '0') {
                     $exif .= ' | <strong>Aperture:</strong>&nbsp;f/' . $value;
                 }
-                if ($key == 'camera') {
+                if ($key == 'camera' && $value != '') {
                     $exif .= ' | <strong>Camera:</strong>&nbsp;' . $value;
                 }
-                if ($key == 'shutter_speed') {
+                if ($key == 'shutter_speed' && $value != '0') {
                     $exif .= ' | <strong>Exposure time:</strong>&nbsp;' . self::format_exp_time($value);
                 }
-                if ($key == 'focal_length') {
+                if ($key == 'focal_length' && $value != '0') {
                     $exif .= ' | <strong>Focal length:</strong>&nbsp;' . $value . ' mm';
                 }
-                if ($key == 'iso') {
+                if ($key == 'iso' && $value != '0') {
                     $exif .= ' | <strong>ISO:</strong>&nbsp;' . $value;
                 }
             }
+            if (!$exif)
+                $exifIsEmpty = true;
 
-            $output .= '<span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>';
+            $output .= (!$exifIsEmpty) ? '<span class="mdLabel">exif</span><span class="exif">' . $exif . '</span>' : '';
         }
 
-        echo $output;
+        if(!$exifIsEmpty)
+            echo $output;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
       "name": "Jonas Kjaergaard",
       "email": "jonas.kjaergaard@bonnier.dk",
       "homepage": ""
+    },
+    {
+      "name": "Michael Sørensen",
+      "email": "michael.sorensen@bonnier.dk"
     }
   ],
   "support": {


### PR DESCRIPTION
This pull requests adds support for images uploadet by WordPress attachments. 
So new posts with an inline images saved as a attachment now displays EXIF data.